### PR TITLE
fix: `base_url` formatting error

### DIFF
--- a/mar/src/types.rs
+++ b/mar/src/types.rs
@@ -111,12 +111,10 @@ impl<T: ToString> MavenArtifactBuilder<T> {
     }
 
     pub fn build(self) -> Result<MavenArtifact, MavenArtifactBuildError> {
-        let base_url = format!(
-            "https://{}",
-            self.base_url
-                .ok_or(MavenArtifactBuildError::BaseURL)
-                .map(|base_url| base_url.to_string())?
-        );
+        let base_url = self
+            .base_url
+            .ok_or(MavenArtifactBuildError::BaseURL)
+            .map(|base_url| base_url.to_string())?;
         let group_id = self
             .group_id
             .ok_or(MavenArtifactBuildError::GroupID)


### PR DESCRIPTION
i seriously dont know why it manifested itself now out of all times

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the `base_url` formatting error in the MavenArtifactBuilder by removing the hardcoded 'https://' prefix, allowing the base URL to be correctly constructed.

Bug Fixes:
- Fix the `base_url` formatting error by removing the hardcoded 'https://' prefix and ensuring the URL is correctly constructed from the provided base URL.

<!-- Generated by sourcery-ai[bot]: end summary -->