### PR TITLE
made workflow ignore file-dependent crates `mparse` and `modparser`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Clippy code lint
+# didnt write this btw 🤡
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  clippy:
+    name: Run rust-clippy analyzing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1 #@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+          override: true
+
+      - name: Run rust-clippy
+        run:
+          cargo clippy
+          --all-features
+          --message-format=json
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Clippy code lint
+name: Clippy
 # didnt write this btw 🤡
 
 on:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   clippy:
-    name: Run rust-clippy analyzing
+    name: Code Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --workspace --exclude '*parse*' --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: Rust
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Rust code testing
 
 on:
   push:


### PR DESCRIPTION
FINAL AMEND BRO PLEASE 😭🙏

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Modify the CI test workflow to exclude specific file-dependent crates, `mparse` and `modparser`, from being tested.

CI:
- Update the test workflow to exclude file-dependent crates `mparse` and `modparser` from the test suite.

<!-- Generated by sourcery-ai[bot]: end summary -->